### PR TITLE
Add emulator configuration for GMR topic and subscription

### DIFF
--- a/compose/asbconfig.json
+++ b/compose/asbconfig.json
@@ -3,7 +3,6 @@
     "Namespaces": [
       {
         "Name": "sbemulatorns",
-
         "Topics": [
           {
             "Name": "dev_alvs_topic_vnet",
@@ -29,6 +28,28 @@
           },
           {
             "Name": "dev_notification_topic_vnet",
+            "Properties": {
+              "DefaultMessageTimeToLive": "PT1H",
+              "DuplicateDetectionHistoryTimeWindow": "PT20S",
+              "RequiresDuplicateDetection": false
+            },
+            "Subscriptions": [
+              {
+                "Name": "dev_btms_sub_vnet",
+                "Properties": {
+                  "DeadLetteringOnMessageExpiration": false,
+                  "DefaultMessageTimeToLive": "PT1H",
+                  "LockDuration": "PT1M",
+                  "MaxDeliveryCount": 10,
+                  "ForwardDeadLetteredMessagesTo": "",
+                  "ForwardTo": "",
+                  "RequiresSession": false
+                }
+              }
+            ]
+          },
+          {
+            "Name": "dev_gmr_topic_vnet",
             "Properties": {
               "DefaultMessageTimeToLive": "PT1H",
               "DuplicateDetectionHistoryTimeWindow": "PT20S",


### PR DESCRIPTION
As per PR title.

Replicating ASB emulator configuration that was added for the two existing topics.